### PR TITLE
Fix cancelled jobs persisting in client due to stale hive cache

### DIFF
--- a/src/main/kotlin/de/devin/cbbees/content/beehive/client/ClientJobCache.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/beehive/client/ClientJobCache.kt
@@ -15,7 +15,27 @@ object ClientJobCache {
     private var cachedJobs: List<ClientJobInfo> = emptyList()
     private var cachedJobsVersion = -1L
 
+    /** Job IDs from the most recent player snapshot — used to detect cancelled/completed jobs. */
+    private var knownPlayerJobIds: Set<java.util.UUID> = emptySet()
+
     fun update(pos: BlockPos, snapshot: HiveSnapshot) {
+        if (pos == BlockPos.ZERO) {
+            // Player snapshot is authoritative for player-owned jobs.
+            // Purge jobs from stale hive snapshots that the player no longer owns
+            // (cancelled or completed since the hive snapshot was last refreshed).
+            val currentIds = snapshot.jobs.map { it.jobId }.toSet()
+            val removedIds = knownPlayerJobIds - currentIds
+            if (removedIds.isNotEmpty()) {
+                for ((hivePos, hiveSnapshot) in byHive) {
+                    if (hivePos == BlockPos.ZERO) continue
+                    val filtered = hiveSnapshot.jobs.filter { it.jobId !in removedIds }
+                    if (filtered.size != hiveSnapshot.jobs.size) {
+                        byHive[hivePos] = HiveSnapshot(hiveSnapshot.networkInfo, filtered)
+                    }
+                }
+            }
+            knownPlayerJobIds = currentIds
+        }
         byHive[pos] = snapshot
         version++
     }
@@ -24,7 +44,7 @@ object ClientJobCache {
 
     fun getAllJobs(): List<ClientJobInfo> {
         if (cachedJobsVersion != version) {
-            cachedJobs = byHive.values.flatMap { it.jobs }
+            cachedJobs = byHive.values.flatMap { it.jobs }.distinctBy { it.jobId }
             cachedJobsVersion = version
         }
         return cachedJobs

--- a/src/main/kotlin/de/devin/cbbees/network/CancelJobPacket.kt
+++ b/src/main/kotlin/de/devin/cbbees/network/CancelJobPacket.kt
@@ -20,7 +20,11 @@ class CancelJobPacket(val jobId: UUID) : CustomPacketPayload {
 
         fun handle(payload: CancelJobPacket, ctx: IPayloadContext) {
             ctx.enqueueWork {
-                GlobalJobPool.getAllJobs().firstOrNull { it.jobId == payload.jobId }?.cancel()
+                val job = GlobalJobPool.getAllJobs().firstOrNull { it.jobId == payload.jobId }
+                job?.cancel()
+                // Immediately sync so the client cache drops the cancelled job
+                val player = ctx.player() as? net.minecraft.server.level.ServerPlayer ?: return@enqueueWork
+                HiveJobsSyncPacket.sendPlayerSnapshotTo(player)
             }
         }
     }


### PR DESCRIPTION
When a job was cancelled, the server removed it from the player snapshot but stale hive snapshots in ClientJobCache still contained the old job data. This caused the outline and cancel dialog to persist — clicking cancel again found nothing server-side, so it appeared to have no effect.

- Track known player job IDs in ClientJobCache; when the player snapshot arrives, purge removed IDs from all hive snapshots
- Deduplicate getAllJobs() by jobId to prevent duplicates across snapshots
- Send an immediate player snapshot after CancelJobPacket so the client updates without waiting for the next periodic sync