### PR TITLE
Fix Sable compatibility and component-sensitive schematic materials

### DIFF
--- a/src/main/java/de/devin/cbbees/mixin/SchematicHandlerHudMixin.java
+++ b/src/main/java/de/devin/cbbees/mixin/SchematicHandlerHudMixin.java
@@ -111,14 +111,27 @@ public abstract class SchematicHandlerHudMixin {
             ConstructionToolState.setActiveTool(ConstructionToolState.CustomTool.NONE);
             cir.setReturnValue(true);
         } else if (tool == ConstructionToolState.CustomTool.PROGRAM) {
-            // Read placement data and send a ProgramSchematicPacket
+            // Read live placement data from Create's SchematicTransformation.
+            // The ItemStack components only store the first deploy anchor and are not
+            // updated immediately by Move XZ / Move Y / Rotate / Mirror tools. Those
+            // tools update the transformation and only sync later via Create's normal
+            // SchematicSyncPacket. Programming from the ItemStack therefore rolled the
+            // schematic back to its first clicked position. This must match Construct.
             String schematicFile = mainHand.get(AllDataComponents.SCHEMATIC_FILE);
             String owner = mainHand.get(AllDataComponents.SCHEMATIC_OWNER);
             if (schematicFile == null || owner == null) return;
 
-            BlockPos anchor = mainHand.getOrDefault(AllDataComponents.SCHEMATIC_ANCHOR, BlockPos.ZERO);
-            Rotation rotation = mainHand.getOrDefault(AllDataComponents.SCHEMATIC_ROTATION, Rotation.NONE);
-            Mirror mirror = mainHand.getOrDefault(AllDataComponents.SCHEMATIC_MIRROR, Mirror.NONE);
+            var transform = CreateClient.SCHEMATIC_HANDLER.getTransformation();
+            var settings = transform.toSettings();
+            BlockPos anchor = transform.getAnchor();
+            Rotation rotation = settings.getRotation();
+            Mirror mirror = settings.getMirror();
+
+            // Keep the client stack coherent too. This avoids later local reads using
+            // stale placement data after the user presses Program.
+            mainHand.set(AllDataComponents.SCHEMATIC_ANCHOR, anchor);
+            mainHand.set(AllDataComponents.SCHEMATIC_ROTATION, rotation);
+            mainHand.set(AllDataComponents.SCHEMATIC_MIRROR, mirror);
 
             SchematicProgram program = new SchematicProgram.Construction(
                 schematicFile, anchor, rotation, mirror, owner

--- a/src/main/kotlin/de/devin/cbbees/compat/sable/SableRenderSupport.kt
+++ b/src/main/kotlin/de/devin/cbbees/compat/sable/SableRenderSupport.kt
@@ -1,0 +1,56 @@
+package de.devin.cbbees.compat.sable
+
+import net.minecraft.core.Position
+import net.minecraft.world.level.Level
+import net.minecraft.world.phys.Vec3
+
+/**
+ * Optional client-side bridge for rendering Buzzy Bees flight-plan bees inside Sable sub-levels.
+ *
+ * This file intentionally uses reflection only. Buzzy Bees can still run without Sable installed,
+ * and the schematic/deployer/planner logic remains unchanged from 1.3.3.
+ */
+object SableRenderSupport {
+    private val sableClass: Class<*>? by lazy {
+        runCatching { Class.forName("dev.ryanhcode.sable.Sable") }.getOrNull()
+    }
+
+    private val helperInstance: Any? by lazy {
+        runCatching { sableClass?.getField("HELPER")?.get(null) }.getOrNull()
+    }
+
+    private val helperClass: Class<*>? by lazy { helperInstance?.javaClass }
+
+    private val projectOutOfSubLevelMethod by lazy {
+        runCatching {
+            helperClass?.getMethod(
+                "projectOutOfSubLevel",
+                Level::class.java,
+                Position::class.java
+            )
+        }.getOrNull()
+    }
+
+    private val distanceSquaredWithSubLevelsMethod by lazy {
+        runCatching {
+            helperClass?.getMethod(
+                "distanceSquaredWithSubLevels",
+                Level::class.java,
+                Position::class.java,
+                Position::class.java
+            )
+        }.getOrNull()
+    }
+
+    fun projectOutOfSubLevel(level: Level, pos: Position): Vec3? {
+        val helper = helperInstance ?: return null
+        val method = projectOutOfSubLevelMethod ?: return null
+        return runCatching { method.invoke(helper, level, pos) as? Vec3 }.getOrNull()
+    }
+
+    fun distanceSquaredWithSubLevels(level: Level, posA: Position, posB: Position): Double? {
+        val helper = helperInstance ?: return null
+        val method = distanceSquaredWithSubLevelsMethod ?: return null
+        return runCatching { method.invoke(helper, level, posA, posB) as? Double }.getOrNull()
+    }
+}

--- a/src/main/kotlin/de/devin/cbbees/config/CBBeesClientConfig.kt
+++ b/src/main/kotlin/de/devin/cbbees/config/CBBeesClientConfig.kt
@@ -61,4 +61,19 @@ object CBBeesClientConfig {
 
         SPEC = builder.build()
     }
+
+    private fun <T> safeGet(value: ModConfigSpec.ConfigValue<T>, fallback: T): T {
+        return runCatching { value.get() }.getOrDefault(fallback)
+    }
+
+    fun showConstructionGhostsSafe(): Boolean = safeGet(showConstructionGhosts, true)
+    fun showSchematicPreviewSafe(): Boolean = safeGet(showSchematicPreview, true)
+    fun showBeehiveRangeSafe(): Boolean = safeGet(showBeehiveRange, true)
+    fun showBeeTargetLinesSafe(): Boolean = safeGet(showBeeTargetLines, true)
+    fun ghostBlockOpacitySafe(): Double = safeGet(ghostBlockOpacity, 0.5)
+    fun renderGhostBlockEntitiesSafe(): Boolean = safeGet(renderGhostBlockEntities, false)
+    fun maxGhostBlockEntitiesSafe(): Int = safeGet(maxGhostBlockEntities, 64)
+    fun beeShadowDistanceSafe(): Int = safeGet(beeShadowDistance, 16)
+    fun beeItemRenderDistanceSafe(): Int = safeGet(beeItemRenderDistance, 24)
+
 }

--- a/src/main/kotlin/de/devin/cbbees/content/bee/BumbleBeeCarriedItemLayer.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/bee/BumbleBeeCarriedItemLayer.kt
@@ -30,7 +30,7 @@ class BumbleBeeCarriedItemLayer(renderer: GeoRenderer<MechanicalBumbleBeeEntity>
     ) {
         // Skip item rendering for distant bees
         val cam = Minecraft.getInstance().gameRenderer.mainCamera.position
-        val itemDist = de.devin.cbbees.config.CBBeesClientConfig.beeItemRenderDistance.get()
+        val itemDist = de.devin.cbbees.config.CBBeesClientConfig.beeItemRenderDistanceSafe()
         if (animatable.distanceToSqr(cam) > itemDist.toLong() * itemDist) return
 
         val contents = animatable.getInventoryContents()

--- a/src/main/kotlin/de/devin/cbbees/content/bee/MaterialSource.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/bee/MaterialSource.kt
@@ -3,6 +3,7 @@ package de.devin.cbbees.content.bee
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.entity.player.Player
 import net.minecraft.core.BlockPos
+import net.minecraft.core.Direction
 import net.minecraft.world.level.Level
 import net.neoforged.neoforge.capabilities.Capabilities
 import net.neoforged.neoforge.items.ItemHandlerHelper
@@ -34,7 +35,7 @@ class PlayerMaterialSource(private val player: Player) : MaterialSource {
     override fun extractItems(required: ItemStack, amount: Int): ItemStack {
         for (i in 0 until player.inventory.containerSize) {
             val stack = player.inventory.getItem(i)
-            if (ItemStack.isSameItem(stack, required)) {
+            if (ItemStack.isSameItemSameComponents(stack, required)) {
                 return player.inventory.removeItem(i, amount)
             }
         }
@@ -56,11 +57,11 @@ class PlayerMaterialSource(private val player: Player) : MaterialSource {
 class WirelessMaterialSource(private val level: Level, private val positions: List<BlockPos>) : MaterialSource {
     override fun extractItems(required: ItemStack, amount: Int): ItemStack {
         for (pos in positions) {
-            val handler = level.getCapability(Capabilities.ItemHandler.BLOCK, pos, null)
+            val handler = level.getCapability(Capabilities.ItemHandler.BLOCK, pos, null as Direction?)
             if (handler != null) {
                 for (slot in 0 until handler.slots) {
                     val stack = handler.getStackInSlot(slot)
-                    if (ItemStack.isSameItem(stack, required)) {
+                    if (ItemStack.isSameItemSameComponents(stack, required)) {
                         return handler.extractItem(slot, amount, false)
                     }
                 }
@@ -72,7 +73,7 @@ class WirelessMaterialSource(private val level: Level, private val positions: Li
     override fun insertItems(stack: ItemStack): ItemStack {
         var current = stack
         for (pos in positions) {
-            val handler = level.getCapability(Capabilities.ItemHandler.BLOCK, pos, null)
+            val handler = level.getCapability(Capabilities.ItemHandler.BLOCK, pos, null as Direction?)
             if (handler != null) {
                 current = ItemHandlerHelper.insertItem(handler, current, false)
                 if (current.isEmpty) return ItemStack.EMPTY
@@ -179,7 +180,7 @@ class AdjacentInventoryCache(
     private fun scanForInventories(): List<BlockPos> {
         val positions = AdjacentPositions.getAdjacentPositions(center, range)
         return positions.filter { pos ->
-            level.getCapability(Capabilities.ItemHandler.BLOCK, pos, null) != null
+            level.getCapability(Capabilities.ItemHandler.BLOCK, pos, null as Direction?) != null
         }
     }
     

--- a/src/main/kotlin/de/devin/cbbees/content/bee/MechanicalBeeRenderer.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/bee/MechanicalBeeRenderer.kt
@@ -33,7 +33,7 @@ class MechanicalBeeRenderer(context: EntityRendererProvider.Context) :
         // Distance-based shadow culling
         val cam = Minecraft.getInstance().gameRenderer.mainCamera.position
         val distSq = entity.distanceToSqr(cam)
-        val shadowDist = de.devin.cbbees.config.CBBeesClientConfig.beeShadowDistance.get()
+        val shadowDist = de.devin.cbbees.config.CBBeesClientConfig.beeShadowDistanceSafe()
         this.shadowRadius = if (distSq < shadowDist.toLong() * shadowDist) 0.3f else 0.0f
 
         super.render(entity, entityYaw, partialTick, poseStack, bufferSource, packedLight)

--- a/src/main/kotlin/de/devin/cbbees/content/bee/MechanicalBumbleBeeRenderer.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/bee/MechanicalBumbleBeeRenderer.kt
@@ -28,7 +28,7 @@ class MechanicalBumbleBeeRenderer(context: EntityRendererProvider.Context) :
         // Distance-based shadow culling
         val cam = Minecraft.getInstance().gameRenderer.mainCamera.position
         val distSq = entity.distanceToSqr(cam)
-        val shadowDist = de.devin.cbbees.config.CBBeesClientConfig.beeShadowDistance.get()
+        val shadowDist = de.devin.cbbees.config.CBBeesClientConfig.beeShadowDistanceSafe()
         this.shadowRadius = if (distSq < shadowDist.toLong() * shadowDist) 0.3f else 0.0f
 
         super.render(entity, entityYaw, partialTick, poseStack, bufferSource, packedLight)

--- a/src/main/kotlin/de/devin/cbbees/content/bee/client/BeeTargetLineHandler.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/bee/client/BeeTargetLineHandler.kt
@@ -42,7 +42,7 @@ object BeeTargetLineHandler {
             profiler?.pop()
         }
 
-        if (!CBBeesClientConfig.showBeeTargetLines.get()) return
+        if (!CBBeesClientConfig.showBeeTargetLinesSafe()) return
 
         val player = mc.player ?: return
         mc.level ?: return

--- a/src/main/kotlin/de/devin/cbbees/content/bee/client/BeeWorldRenderer.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/bee/client/BeeWorldRenderer.kt
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack
 import com.mojang.blaze3d.vertex.VertexConsumer
 import com.mojang.math.Axis
 import de.devin.cbbees.CreateBuzzyBeez
+import de.devin.cbbees.compat.sable.SableRenderSupport
 import de.devin.cbbees.content.bee.server.BeeType
 import de.devin.cbbees.util.ClientSide
 import net.minecraft.client.Minecraft
@@ -63,11 +64,15 @@ object BeeWorldRenderer {
         val time = System.nanoTime() / 1_000_000_000.0f
 
         flightBees.forEach { bee ->
-            val pos = bee.lerpPos(partialTick)
-            val dx = pos.x - camPos.x
-            val dy = pos.y - camPos.y
-            val dz = pos.z - camPos.z
-            if (dx * dx + dy * dy + dz * dz > maxDistSq) return@forEach
+            val rawPos = bee.lerpPos(partialTick)
+            val renderPos = SableRenderSupport.projectOutOfSubLevel(level, rawPos) ?: rawPos
+            val distSq = SableRenderSupport.distanceSquaredWithSubLevels(level, rawPos, camPos)
+                ?: renderPos.distanceToSqr(camPos)
+            if (distSq > maxDistSq) return@forEach
+
+            val dx = renderPos.x - camPos.x
+            val dy = renderPos.y - camPos.y
+            val dz = renderPos.z - camPos.z
 
             val (modelRes, textureRes) = when (bee.type) {
                 BeeType.CONSTRUCTION -> BEE_MODEL to BEE_TEXTURE

--- a/src/main/kotlin/de/devin/cbbees/content/beehive/client/BeehiveRangeHandler.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/beehive/client/BeehiveRangeHandler.kt
@@ -28,7 +28,7 @@ object BeehiveRangeHandler {
     @SubscribeEvent
     @JvmStatic
     fun onClientTick(event: ClientTickEvent.Post) {
-        if (!CBBeesClientConfig.showBeehiveRange.get()) {
+        if (!CBBeesClientConfig.showBeehiveRangeSafe()) {
             clearAllSlots()
             return
         }

--- a/src/main/kotlin/de/devin/cbbees/content/domain/beehive/PortableBeeHive.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/domain/beehive/PortableBeeHive.kt
@@ -257,7 +257,7 @@ class PortableBeeHive(val player: Player) : BeeHive, LogisticsPort {
         if (player.isCreative) return true
         for (i in 0 until player.inventory.containerSize) {
             val slot = player.inventory.getItem(i)
-            if (!slot.isEmpty && ItemStack.isSameItem(slot, stack) && slot.count >= stack.count) {
+            if (!slot.isEmpty && ItemStack.isSameItemSameComponents(slot, stack) && slot.count >= stack.count) {
                 return true
             }
         }
@@ -278,7 +278,7 @@ class PortableBeeHive(val player: Player) : BeeHive, LogisticsPort {
         var count = 0
         for (i in 0 until player.inventory.containerSize) {
             val slot = player.inventory.getItem(i)
-            if (!slot.isEmpty && ItemStack.isSameItem(slot, stack)) {
+            if (!slot.isEmpty && ItemStack.isSameItemSameComponents(slot, stack)) {
                 count += slot.count
             }
         }
@@ -296,7 +296,7 @@ class PortableBeeHive(val player: Player) : BeeHive, LogisticsPort {
                 ?: continue
             for (slot in 0 until handler.slots) {
                 val slotStack = handler.getStackInSlot(slot)
-                if (!slotStack.isEmpty && ItemStack.isSameItem(slotStack, stack)) {
+                if (!slotStack.isEmpty && ItemStack.isSameItemSameComponents(slotStack, stack)) {
                     count += slotStack.count
                 }
             }
@@ -325,7 +325,7 @@ class PortableBeeHive(val player: Player) : BeeHive, LogisticsPort {
         var remaining = stack.count
         for (i in 0 until player.inventory.containerSize) {
             val slot = player.inventory.getItem(i)
-            if (!slot.isEmpty && ItemStack.isSameItem(slot, stack)) {
+            if (!slot.isEmpty && ItemStack.isSameItemSameComponents(slot, stack)) {
                 val take = minOf(remaining, slot.count)
                 slot.shrink(take)
                 if (slot.isEmpty) player.inventory.setItem(i, ItemStack.EMPTY)
@@ -347,7 +347,7 @@ class PortableBeeHive(val player: Player) : BeeHive, LogisticsPort {
                 ?: continue
             for (slot in 0 until handler.slots) {
                 val slotStack = handler.getStackInSlot(slot)
-                if (!slotStack.isEmpty && ItemStack.isSameItem(slotStack, stack) && slotStack.count >= stack.count) {
+                if (!slotStack.isEmpty && ItemStack.isSameItemSameComponents(slotStack, stack) && slotStack.count >= stack.count) {
                     return true
                 }
             }
@@ -366,7 +366,7 @@ class PortableBeeHive(val player: Player) : BeeHive, LogisticsPort {
             for (slot in 0 until handler.slots) {
                 if (remaining <= 0) break
                 val slotStack = handler.getStackInSlot(slot)
-                if (!slotStack.isEmpty && ItemStack.isSameItem(slotStack, stack)) {
+                if (!slotStack.isEmpty && ItemStack.isSameItemSameComponents(slotStack, stack)) {
                     val extracted = handler.extractItem(slot, remaining, false)
                     remaining -= extracted.count
                 }

--- a/src/main/kotlin/de/devin/cbbees/content/logistics/ports/LogisticsPortBlockEntity.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/logistics/ports/LogisticsPortBlockEntity.kt
@@ -43,7 +43,6 @@ class LogisticPortBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: Bl
             onNetworkIdChanged(old, value)
         }
 
-    var filterStack: ItemStack = ItemStack.EMPTY
     var priority = 0
 
     private val reservationManager = de.devin.cbbees.content.domain.logistics.PortReservationManager()
@@ -110,22 +109,16 @@ class LogisticPortBlockEntity(type: BlockEntityType<*>, pos: BlockPos, state: Bl
         if (tag.hasUUID("NetworkId")) {
             networkId = tag.getUUID("NetworkId")
         }
-        if (tag.contains("Filter")) {
-            filterStack = ItemStack.parseOptional(registries, tag.getCompound("Filter"))
-        }
     }
 
     override fun write(tag: CompoundTag, registries: HolderLookup.Provider, clientPacket: Boolean) {
         super.write(tag, registries, clientPacket)
         tag.putUUID("lp_id", id)
         tag.putUUID("NetworkId", networkId)
-        if (!filterStack.isEmpty) {
-            tag.put("Filter", filterStack.save(registries))
-        }
     }
 
     override fun getFilter(): ItemStack {
-        return filterStack
+        return if (::filteringBehavior.isInitialized) filteringBehavior.getFilter() else ItemStack.EMPTY
     }
 
     override fun getItemHandler(level: Level): IItemHandler? {

--- a/src/main/kotlin/de/devin/cbbees/content/schematics/SchematicCreateBridge.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/schematics/SchematicCreateBridge.kt
@@ -344,20 +344,64 @@ class SchematicCreateBridge(
     }
 
     /**
-     * Convert Create's ItemRequirement to a list of ItemStacks
+     * Convert Create's ItemRequirement to material stacks consumed by bees.
+     *
+     * Create can report both a default/plain item stack and a component-rich stack for
+     * the same represented block. For component-sensitive blocks (for example CBC
+     * shells with fuze data, or Copycat blocks with material data), keeping both
+     * stacks makes bees consume the plain item and the component item together.
+     *
+     * Rules:
+     * - only CONSUME requirements become bee material requirements
+     * - merge exact same item + component stacks
+     * - when the same item has a special component stack, drop the plain/default
+     *   duplicate and keep the component stack
      */
     private fun getItemsFromRequirement(requirement: ItemRequirement): List<ItemStack> {
         if (requirement.isInvalid) return emptyList()
 
-        val items = mutableListOf<ItemStack>()
+        val rawItems = mutableListOf<ItemStack>()
 
-        // Get required items from the requirement
-        // StackRequirement has a 'stack' field containing the ItemStack
         requirement.requiredItems.forEach { reqItem ->
-            items.add(reqItem.stack.copy())
+            if (reqItem.usage != ItemRequirement.ItemUseType.CONSUME) return@forEach
+
+            val stack = reqItem.stack.copy()
+            if (!stack.isEmpty) {
+                rawItems.add(stack)
+            }
         }
 
-        return items
+        if (rawItems.isEmpty()) return emptyList()
+
+        val result = mutableListOf<ItemStack>()
+
+        rawItems.forEach { stack ->
+            val sameItemHasSpecialStack = rawItems.any { other ->
+                ItemStack.isSameItem(other, stack) && hasSpecialComponents(other)
+            }
+
+            if (!hasSpecialComponents(stack) && sameItemHasSpecialStack) {
+                return@forEach
+            }
+
+            val existing = result.firstOrNull { existing ->
+                ItemStack.isSameItemSameComponents(existing, stack)
+            }
+
+            if (existing != null) {
+                existing.grow(stack.count)
+            } else {
+                result.add(stack.copy())
+            }
+        }
+
+        return result
+    }
+
+    private fun hasSpecialComponents(stack: ItemStack): Boolean {
+        if (stack.isEmpty) return false
+        val defaultStack = stack.item.defaultInstance
+        return !ItemStack.isSameItemSameComponents(stack, defaultStack)
     }
 
 

--- a/src/main/kotlin/de/devin/cbbees/content/schematics/client/ConstructionRenderer.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/schematics/client/ConstructionRenderer.kt
@@ -102,7 +102,7 @@ object ConstructionRenderer {
     @JvmStatic
     fun onRenderLevel(event: RenderLevelStageEvent) {
         if (event.stage != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) return
-        if (!CBBeesClientConfig.showConstructionGhosts.get()) return
+        if (!CBBeesClientConfig.showConstructionGhostsSafe()) return
 
         val mc = Minecraft.getInstance()
         val level = mc.level ?: return
@@ -139,7 +139,7 @@ object ConstructionRenderer {
         val poseStack = event.poseStack
         val camera = mc.gameRenderer.mainCamera.position
         val superBuffer = DefaultSuperRenderTypeBuffer.getInstance()
-        val opacity = CBBeesClientConfig.ghostBlockOpacity.get().toFloat()
+        val opacity = CBBeesClientConfig.ghostBlockOpacitySafe().toFloat()
         val transparentBuffer = TransparentBuffer(superBuffer, opacity)
 
         profiler.push("renderGhosts")

--- a/src/main/kotlin/de/devin/cbbees/content/schematics/client/GhostSchematicRenderer.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/schematics/client/GhostSchematicRenderer.kt
@@ -101,8 +101,8 @@ class GhostSchematicRenderer(world: SchematicLevel) : SchematicRenderer(world) {
             buffer.renderInto(ms, buffers.getBuffer(layer))
         }
 
-        if (CBBeesClientConfig.renderGhostBlockEntities.get()) {
-            val max = CBBeesClientConfig.maxGhostBlockEntities.get()
+        if (CBBeesClientConfig.renderGhostBlockEntitiesSafe()) {
+            val max = CBBeesClientConfig.maxGhostBlockEntitiesSafe()
             val allBEs = schematic.renderedBlockEntities.toList()
             val capped = if (allBEs.size > max) allBEs.subList(0, max) else allBEs
             val shouldRender = BitSet(capped.size)

--- a/src/main/kotlin/de/devin/cbbees/content/schematics/client/SchematicHoverPreview.kt
+++ b/src/main/kotlin/de/devin/cbbees/content/schematics/client/SchematicHoverPreview.kt
@@ -197,7 +197,7 @@ object SchematicHoverPreview {
 
     fun render(event: RenderLevelStageEvent) {
         if (event.stage != RenderLevelStageEvent.Stage.AFTER_PARTICLES) return
-        if (!CBBeesClientConfig.showSchematicPreview.get()) return
+        if (!CBBeesClientConfig.showSchematicPreviewSafe()) return
         if (!ConstructionPlannerHandler.isBrowsingPreview) return
         if (currentSchematic == null || schematicSize == Vec3i.ZERO) return
 
@@ -218,7 +218,7 @@ object SchematicHoverPreview {
         // Render ghost blocks only if renderer is ready (built asynchronously)
         val renderer = getActiveRenderer()
         if (renderer != null) {
-            val opacity = CBBeesClientConfig.ghostBlockOpacity.get().toFloat()
+            val opacity = CBBeesClientConfig.ghostBlockOpacitySafe().toFloat()
             val transparentBuffer = TransparentBuffer(superBuffer, opacity)
             poseStack.pushPose()
 

--- a/src/main/kotlin/de/devin/cbbees/network/DeployerSettingsPacket.kt
+++ b/src/main/kotlin/de/devin/cbbees/network/DeployerSettingsPacket.kt
@@ -1,6 +1,7 @@
 package de.devin.cbbees.network
 
 import de.devin.cbbees.CreateBuzzyBeez
+import de.devin.cbbees.compat.sable.SableRenderSupport
 import de.devin.cbbees.content.deployer.DeployMode
 import de.devin.cbbees.content.deployer.SchematicDeployerBlockEntity
 import net.minecraft.core.BlockPos
@@ -10,11 +11,13 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.level.block.Mirror
 import net.minecraft.world.level.block.Rotation
+import net.minecraft.world.phys.Vec3
 import net.neoforged.neoforge.network.handling.IPayloadContext
 
 /**
- * Client -> Server packet sent when the player changes deploy mode, relative offset,
- * or rotation/mirror overrides in the Schematic Deployer GUI.
+ * Client -> Server packet sent when the player changes deploy mode,
+ * relative offset, or rotation/mirror overrides in the
+ * Schematic Deployer GUI.
  */
 class DeployerSettingsPacket(
     val deployerPos: BlockPos,
@@ -29,44 +32,86 @@ class DeployerSettingsPacket(
             CreateBuzzyBeez.asResource("deployer_settings")
         )
 
-        val STREAM_CODEC: StreamCodec<RegistryFriendlyByteBuf, DeployerSettingsPacket> = StreamCodec.of(
-            { buf, pkt ->
-                buf.writeBlockPos(pkt.deployerPos)
-                buf.writeEnum(pkt.mode)
-                buf.writeBlockPos(pkt.relativeOffset)
-                buf.writeEnum(pkt.relativeRotation)
-                buf.writeEnum(pkt.relativeMirror)
-            },
-            { buf ->
-                DeployerSettingsPacket(
-                    buf.readBlockPos(),
-                    buf.readEnum(DeployMode::class.java),
-                    buf.readBlockPos(),
-                    buf.readEnum(Rotation::class.java),
-                    buf.readEnum(Mirror::class.java)
-                )
-            }
-        )
+        val STREAM_CODEC:
+            StreamCodec<RegistryFriendlyByteBuf, DeployerSettingsPacket> =
+            StreamCodec.of(
+                { buf, packet ->
+                    buf.writeBlockPos(packet.deployerPos)
+                    buf.writeEnum(packet.mode)
+                    buf.writeBlockPos(packet.relativeOffset)
+                    buf.writeEnum(packet.relativeRotation)
+                    buf.writeEnum(packet.relativeMirror)
+                },
+                { buf ->
+                    DeployerSettingsPacket(
+                        deployerPos = buf.readBlockPos(),
+                        mode = buf.readEnum(DeployMode::class.java),
+                        relativeOffset = buf.readBlockPos(),
+                        relativeRotation = buf.readEnum(Rotation::class.java),
+                        relativeMirror = buf.readEnum(Mirror::class.java)
+                    )
+                }
+            )
 
-        fun handle(payload: DeployerSettingsPacket, context: IPayloadContext) {
+        fun handle(
+            payload: DeployerSettingsPacket,
+            context: IPayloadContext
+        ) {
             context.enqueueWork {
-                val player = context.player() as? ServerPlayer ?: return@enqueueWork
+                val player =
+                    context.player() as? ServerPlayer
+                        ?: return@enqueueWork
+
                 val level = player.serverLevel()
 
-                if (player.blockPosition().distSqr(payload.deployerPos) > 64.0) return@enqueueWork
+                /*
+                 * distSqr() and distanceToSqr() return squared distance.
+                 *
+                 * The old check used:
+                 *
+                 *     distanceSquared > 64.0
+                 *
+                 * which only allowed approximately 8 actual blocks.
+                 *
+                 * Sable sublevels may also use a different coordinate space,
+                 * so use Sable's sublevel-aware distance calculation when
+                 * available, with normal Minecraft distance as fallback.
+                 */
+                val deployerCenter =
+                    Vec3.atCenterOf(payload.deployerPos)
 
-                val be = level.getBlockEntity(payload.deployerPos) as? SchematicDeployerBlockEntity
-                    ?: return@enqueueWork
+                val distanceSquared =
+                    SableRenderSupport.distanceSquaredWithSubLevels(
+                        level,
+                        player.position(),
+                        deployerCenter
+                    ) ?: player.position()
+                        .distanceToSqr(deployerCenter)
 
-                be.deployMode = payload.mode
-                be.relativeOffset = payload.relativeOffset
-                be.relativeRotation = payload.relativeRotation
-                be.relativeMirror = payload.relativeMirror
-                be.setChanged()
-                be.sendData()
+                val maximumDistance = 64.0
+                val maximumDistanceSquared =
+                    maximumDistance * maximumDistance
+
+                if (distanceSquared > maximumDistanceSquared) {
+                    return@enqueueWork
+                }
+
+                val deployer =
+                    level.getBlockEntity(payload.deployerPos)
+                        as? SchematicDeployerBlockEntity
+                        ?: return@enqueueWork
+
+                deployer.deployMode = payload.mode
+                deployer.relativeOffset = payload.relativeOffset
+                deployer.relativeRotation = payload.relativeRotation
+                deployer.relativeMirror = payload.relativeMirror
+
+                deployer.setChanged()
+                deployer.sendData()
             }
         }
     }
 
-    override fun type(): CustomPacketPayload.Type<out CustomPacketPayload> = TYPE
+    override fun type():
+        CustomPacketPayload.Type<out CustomPacketPayload> = TYPE
 }


### PR DESCRIPTION
- Fix bee rendering in Sable sublevels
- Preserve final schematic Program position
- Fix early client config access crash
- Fix NBT/component material matching
- Prevent plain and component item double deduction
- Preserve Create filter behavior